### PR TITLE
[base-ui][b-nav-side] 侧边根节点支持配置图标

### DIFF
--- a/src/component/b-nav-side/b-nav-side.vue
+++ b/src/component/b-nav-side/b-nav-side.vue
@@ -30,6 +30,11 @@
                             class="action-bar router-level-1"
                             @click="onToggleNavChildrenOpen(rootRoute)"
                         >
+                            <span v-if="rootRoute.meta.hasIcon">
+                                <slot :name="rootRoute.name">
+                                    <i :class="rootRoute.meta.iconClass"></i>
+                                </slot>
+                            </span>
                             {{ rootRoute.meta.navTitle }}
 
                             <span class="toggle-icon">
@@ -45,6 +50,11 @@
                             :class="{active: rootRoute.name === $route.name}"
                             class="action-bar router-level-1"
                         >
+                            <span v-if="rootRoute.meta.hasIcon">
+                                <slot :name="rootRoute.name">
+                                    <i :class="rootRoute.meta.iconClass"></i>
+                                </slot>
+                            </span>
                             {{ rootRoute.meta.navTitle }}
                         </router-link>
 


### PR DESCRIPTION
[base-ui][b-nav-side] 侧边栏根节点支持配置图标
    summary:
    支持两种配置方式:
    1. router.meta.hasIcon=true&&router.meta.iconClass='b-icon-xxx'(base-ui自带 icon)
![image](https://user-images.githubusercontent.com/30330837/57919266-1525be00-78cb-11e9-8af9-752ca51a1ee0.png)
    2. router.meta.hasIcon=true&&具名插槽 name=router.name 中自定图标样式
![image](https://user-images.githubusercontent.com/30330837/57919330-31295f80-78cb-11e9-8387-374e5c92613f.png)
![image](https://user-images.githubusercontent.com/30330837/57919388-5027f180-78cb-11e9-80c6-c763358bc0c6.png)

![image](https://user-images.githubusercontent.com/30330837/57919305-266eca80-78cb-11e9-8bde-4f5e187be8b1.png)


